### PR TITLE
fix: Transfer ownership to WTT, remove old logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![Cognifide logo](https://assets.cognifide.com/github/cognifide-logo.png)
-
 # AEM Actions
 
 ## Purpose

--- a/api/src/main/java/com/cognifide/actions/api/ActionReceiver.java
+++ b/api/src/main/java/com/cognifide/actions/api/ActionReceiver.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/cognifide/actions/api/ActionSendException.java
+++ b/api/src/main/java/com/cognifide/actions/api/ActionSendException.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/cognifide/actions/api/ActionSubmitter.java
+++ b/api/src/main/java/com/cognifide/actions/api/ActionSubmitter.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/cognifide/actions/api/package-info.java
+++ b/api/src/main/java/com/cognifide/actions/api/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/ActionSubmitterService.java
+++ b/core/src/main/java/com/cognifide/actions/core/ActionSubmitterService.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/MessageConsumerService.java
+++ b/core/src/main/java/com/cognifide/actions/core/MessageConsumerService.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/TestActionReceiver.java
+++ b/core/src/main/java/com/cognifide/actions/core/TestActionReceiver.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/persist/MessagePersistenceService.java
+++ b/core/src/main/java/com/cognifide/actions/core/persist/MessagePersistenceService.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/persist/Resender.java
+++ b/core/src/main/java/com/cognifide/actions/core/persist/Resender.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/serializer/ActionValueMap.java
+++ b/core/src/main/java/com/cognifide/actions/core/serializer/ActionValueMap.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/serializer/MessageSerializer.java
+++ b/core/src/main/java/com/cognifide/actions/core/serializer/MessageSerializer.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/com/cognifide/actions/core/serializer/ValueMapType.java
+++ b/core/src/main/java/com/cognifide/actions/core/serializer/ValueMapType.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/PushMessageProducer.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/PushMessageProducer.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/PushMessageReceiver.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/PushMessageReceiver.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/active/PushClient.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/active/PushClient.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/active/PushClientRunnable.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/active/PushClientRunnable.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/api/PushReceiver.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/api/PushReceiver.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/api/PushSender.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/api/PushSender.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.push/src/main/java/com/cognifide/actions/msg/push/passive/PushServlet.java
+++ b/msg.push/src/main/java/com/cognifide/actions/msg/push/passive/PushServlet.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.replication/src/main/java/com/cognifide/actions/msg/replication/Configuration.java
+++ b/msg.replication/src/main/java/com/cognifide/actions/msg/replication/Configuration.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.replication/src/main/java/com/cognifide/actions/msg/replication/ReplicationMessageProducer.java
+++ b/msg.replication/src/main/java/com/cognifide/actions/msg/replication/ReplicationMessageProducer.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.replication/src/main/java/com/cognifide/actions/msg/replication/cleaner/UserGeneratedContentCleaner.java
+++ b/msg.replication/src/main/java/com/cognifide/actions/msg/replication/cleaner/UserGeneratedContentCleaner.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.replication/src/main/java/com/cognifide/actions/msg/replication/reception/HandleMessageJob.java
+++ b/msg.replication/src/main/java/com/cognifide/actions/msg/replication/reception/HandleMessageJob.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.replication/src/main/java/com/cognifide/actions/msg/replication/reception/MessagePageListener.java
+++ b/msg.replication/src/main/java/com/cognifide/actions/msg/replication/reception/MessagePageListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/api/SocketReceiver.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/api/SocketReceiver.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/api/SocketSender.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/api/SocketSender.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/client/SocketClient.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/client/SocketClient.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/client/SocketClientRunnable.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/client/SocketClientRunnable.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/message/SocketMessageProducer.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/message/SocketMessageProducer.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/message/SocketMessageReceiver.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/message/SocketMessageReceiver.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/ConnectedSockets.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/ConnectedSockets.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/MessageSocket.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/MessageSocket.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/MessageWebsocketServlet.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/MessageWebsocketServlet.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/SocketClosedListener.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/SocketClosedListener.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/WebsocketResponse.java
+++ b/msg.websocket/src/main/java/com/cognifide/actions/msg/websocket/servlet/WebsocketResponse.java
@@ -2,7 +2,7 @@
  * #%L
  * Cognifide Actions
  * %%
- * Copyright (C) 2015 Cognifide
+ * Copyright (C) 2015 Wunderman Thompson Technology
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <name>CQ Actions Parent</name>
     <description>CQ Actions package</description>
-    <url>https://github.com/Cognifide/CQ-Actions</url>
+    <url>https://github.com/wttech/CQ-Actions</url>
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>
@@ -35,7 +35,7 @@
     </properties>
 
     <organization>
-        <name>Cognifide</name>
+        <name>Wunderman Thompson Technology</name>
         <url>http://www.cognifide.com</url>
     </organization>
 
@@ -43,14 +43,14 @@
         <developer>
             <name>Tomasz Rękawek</name>
             <email>tomasz.rekawek@cognifide.com</email>
-            <organization>Cognifide</organization>
+            <organization>Wunderman Thompson Technology</organization>
         </developer>
     </developers>
 
     <scm>
-        <connection>scm:git:https://github.com/Cognifide/CQ-Actions/</connection>
-        <developerConnection>scm:git:https://github.com/Cognifide/CQ-Actions/</developerConnection>
-        <url>https://github.com/Cognifide/CQ-Actions</url>
+        <connection>scm:git:https://github.com/wttech/CQ-Actions/</connection>
+        <developerConnection>scm:git:https://github.com/wttech/CQ-Actions/</developerConnection>
+        <url>https://github.com/wttech/CQ-Actions</url>
       <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
It addresses ownership transfer to Wunderman Thompson Technology. Updates:
- Cognifide logo (removed)
- organization name in pom
- copyright